### PR TITLE
Add battery optimizer and visualisation utilities

### DIFF
--- a/V9_optimizer.py
+++ b/V9_optimizer.py
@@ -1,0 +1,324 @@
+"""Optimizer module for battery trading strategy.
+
+This module defines the :class:`optimizer` used to calculate charge and
+ discharge schedules on the Day Ahead Auction (DAA) and the Intraday
+ Auction (IDA) electricity markets.
+
+It reads price data from Excel spreadsheets and formulates two Pyomo
+ optimisation problems:
+
+* :meth:`step1_optimize_daa` optimises hourly trades for the day ahead
+  market.
+* :meth:`step2_optimize_ida` refines the schedule with quarter-hourly
+  trades on the intraday market while respecting the day-ahead position.
+
+The resulting charge/discharge profiles are returned as lists of values
+ in per-unit of the battery power capability.
+"""
+
+import numpy as np
+import pandas as pd
+import pyomo.environ as pyo
+
+
+class optimizer:
+    """Battery storage optimiser."""
+
+    def __init__(
+        self,
+        n_days: int,
+        n_cycles: int,
+        c_rate: float,
+        energy_cap: float,
+        eta_cha: float,
+        eta_dis: float,
+        min_soc: float,
+        max_soc: float,
+        excel_path_ida: str,
+        excel_path_daa: str,
+    ) -> None:
+        # Battery parameters
+        self.n_days = n_days
+        self.n_hours = int(24 * n_days)
+        self.n_cycles = n_cycles
+        self.c_rate = c_rate
+        self.energy_cap = energy_cap
+        self.power_cap = energy_cap * c_rate
+        self.eta_cha = eta_cha
+        self.eta_dis = eta_dis
+        self.min_soc = min_soc
+        self.max_soc = max_soc
+
+        # Load prices from Excel
+        self.price_list_daa = self._load_prices(excel_path_daa)
+        self.price_list_ida = self._load_prices(excel_path_ida)
+
+        # quarter-hourly copy of day-ahead prices
+        self.price_list_daa_q = np.repeat(self.price_list_daa, 4)
+
+    @staticmethod
+    def _load_prices(path: str) -> list[float]:
+        """Return a list of prices (€/kWh) from an Excel file."""
+        xls = pd.ExcelFile(path)
+        df = xls.parse("1")
+        price_column = df.iloc[24:, 1]
+        prices: list[float] = []
+        for val in price_column:
+            try:
+                price = float(str(val).replace(",", "."))
+                prices.append(price / 1000)
+            except ValueError:
+                continue
+        return prices
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+    @staticmethod
+    def set_highs_solver():
+        """Return pyomo solver using highs."""
+        return pyo.SolverFactory("highs")
+
+    # ------------------------------------------------------------------
+    # Step 1 – Day Ahead optimisation
+    # ------------------------------------------------------------------
+    def step1_optimize_daa(self):
+        """Optimise the day ahead (hourly) trading schedule."""
+        model = pyo.ConcreteModel()
+
+        n_hours = self.n_hours
+        power_cap = self.power_cap
+        eta_cha = self.eta_cha
+        eta_dis = self.eta_dis
+        min_soc = self.min_soc
+        max_soc = self.max_soc
+
+        # Profit trigger
+        best_future_price = [
+            max(self.price_list_daa[t:]) if t < len(self.price_list_daa) else self.price_list_daa[-1]
+            for t in range(len(self.price_list_daa))
+        ]
+        can_charge = [
+            1 if best_future_price[t] * eta_dis > self.price_list_daa[t] / eta_cha else 0
+            for t in range(len(self.price_list_daa))
+        ]
+
+        # Sets
+        model.T = pyo.RangeSet(1, n_hours)
+        model.T_plus_1 = pyo.RangeSet(1, n_hours + 1)
+
+        # Variables
+        model.soc = pyo.Var(model.T_plus_1, domain=pyo.Reals)
+        model.cha_daa = pyo.Var(model.T, domain=pyo.NonNegativeReals, bounds=(0, 1))
+        model.dis_daa = pyo.Var(model.T, domain=pyo.NonNegativeReals, bounds=(0, 1))
+        model.charge_flag = pyo.Var(model.T, domain=pyo.Binary)
+        model.discharge_flag = pyo.Var(model.T, domain=pyo.Binary)
+
+        # Profit trigger param
+        model.can_charge = pyo.Param(
+            model.T,
+            initialize={t + 1: can_charge[t] for t in range(n_hours)},
+            within=pyo.Binary,
+        )
+
+        # Logical constraints
+        model.cha_flag_constraint = pyo.Constraint(model.T, rule=lambda m, t: m.cha_daa[t] <= m.charge_flag[t])
+        model.dis_flag_constraint = pyo.Constraint(model.T, rule=lambda m, t: m.dis_daa[t] <= m.discharge_flag[t])
+        model.no_simultaneous = pyo.Constraint(model.T, rule=lambda m, t: m.charge_flag[t] + m.discharge_flag[t] <= 1)
+
+        model.charge_profit_trigger = pyo.Constraint(model.T, rule=lambda m, t: m.cha_daa[t] <= m.can_charge[t])
+
+        # SoC constraints
+        model.set_maximum_soc = pyo.Constraint(model.T_plus_1, rule=lambda m, t: m.soc[t] <= max_soc)
+        model.set_minimum_soc = pyo.Constraint(model.T_plus_1, rule=lambda m, t: m.soc[t] >= min_soc)
+        model.set_first_soc_to_min = pyo.Constraint(rule=lambda m: m.soc[1] == min_soc)
+        model.set_last_soc_to_min = pyo.Constraint(rule=lambda m: m.soc[n_hours + 1] == min_soc)
+
+        volume_limit = (self.max_soc - self.min_soc) * self.n_cycles * (n_hours / 24)
+        model.charge_cycle_limit = pyo.Constraint(
+            rule=lambda m: sum(m.cha_daa[t] * power_cap * eta_cha for t in m.T) <= volume_limit
+        )
+        model.discharge_cycle_limit = pyo.Constraint(
+            rule=lambda m: sum(m.dis_daa[t] * power_cap for t in m.T) <= volume_limit
+        )
+
+        # SoC dynamics
+        def soc_step(m, t):
+            return m.soc[t + 1] == m.soc[t] + eta_cha * power_cap * m.cha_daa[t] - (1 / eta_dis) * power_cap * m.dis_daa[t]
+
+        model.soc_step_constraint = pyo.Constraint(model.T, rule=soc_step)
+
+        # Objective
+        model.obj = pyo.Objective(
+            expr=sum(power_cap * self.price_list_daa[t - 1] * (model.dis_daa[t] - model.cha_daa[t]) for t in model.T),
+            sense=pyo.maximize,
+        )
+
+        solver = self.set_highs_solver()
+        solver.solve(model)
+
+        soc = [model.soc[t].value for t in range(1, n_hours + 1)]
+        cha = [model.cha_daa[t].value for t in range(1, n_hours + 1)]
+        dis = [model.dis_daa[t].value for t in range(1, n_hours + 1)]
+
+        profit = sum(
+            power_cap * p * (d - c)
+            for c, d, p in zip(cha, dis, self.price_list_daa)
+        )
+
+        chaq = np.repeat(cha, 4)
+        disq = np.repeat(dis, 4)
+        socq = np.repeat(soc, 4)
+        cha_real = [float(x * power_cap / 4 * eta_cha) for x in chaq]
+        dis_real = [float(x * power_cap / 4 / eta_dis) for x in disq]
+
+        return soc, socq, chaq, disq, profit, cha, dis, cha_real, dis_real
+
+    # ------------------------------------------------------------------
+    # Step 2 – Intraday optimisation
+    # ------------------------------------------------------------------
+    def step2_optimize_ida(
+        self,
+        n_hours: int,
+        energy_cap: float,
+        power_cap: float,
+        eta_cha: float,
+        eta_dis: float,
+        step1_cha_daa: list,
+        step1_dis_daa: list,
+    ):
+        """Refine schedule quarter-hourly for the intraday market."""
+        model = pyo.ConcreteModel()
+
+        min_soc = self.min_soc
+        max_soc = self.max_soc
+        N = 4 * n_hours
+
+        model.Q = pyo.RangeSet(1, N)
+        model.Q_plus_1 = pyo.RangeSet(1, N + 1)
+
+        can_close_buy = [1 if self.price_list_ida[i] < self.price_list_daa_q[i] else 0 for i in range(N)]
+        can_close_sell = [1 if self.price_list_ida[i] > self.price_list_daa_q[i] else 0 for i in range(N)]
+        model.can_close_buy = pyo.Param(model.Q, initialize={i + 1: can_close_buy[i] for i in range(N)}, within=pyo.Binary)
+        model.can_close_sell = pyo.Param(
+            model.Q, initialize={i + 1: can_close_sell[i] for i in range(N)}, within=pyo.Binary
+        )
+
+        # Profit trigger similar as step1
+        best_future_price = [
+            max(self.price_list_ida[t:]) if t < len(self.price_list_ida) else self.price_list_ida[-1]
+            for t in range(len(self.price_list_ida))
+        ]
+        can_charge = [
+            1 if best_future_price[t] * eta_dis > self.price_list_ida[t] / eta_cha else 0
+            for t in range(len(self.price_list_ida))
+        ]
+        model.can_charge = pyo.Param(model.Q, initialize={q: can_charge[q - 1] for q in range(1, N + 1)}, within=pyo.Binary)
+
+        # Variables
+        model.soc = pyo.Var(model.Q_plus_1, domain=pyo.Reals)
+        model.cha_ida = pyo.Var(model.Q, domain=pyo.NonNegativeReals, bounds=(0, 1))
+        model.dis_ida = pyo.Var(model.Q, domain=pyo.NonNegativeReals, bounds=(0, 1))
+        model.cha_ida_close = pyo.Var(model.Q, domain=pyo.NonNegativeReals, bounds=(0, 1))
+        model.dis_ida_close = pyo.Var(model.Q, domain=pyo.NonNegativeReals, bounds=(0, 1))
+
+        model.charge_profit_trigger = pyo.Constraint(model.Q, rule=lambda m, t: m.cha_ida[t] <= m.can_charge[t])
+
+        model.set_max_soc = pyo.Constraint(model.Q_plus_1, rule=lambda m, q: m.soc[q] <= max_soc)
+        model.set_min_soc = pyo.Constraint(model.Q_plus_1, rule=lambda m, q: m.soc[q] >= min_soc)
+        model.set_soc_start = pyo.Constraint(rule=lambda m: m.soc[1] == min_soc)
+        model.set_soc_end = pyo.Constraint(rule=lambda m: m.soc[N + 1] == min_soc)
+
+        def soc_step(m, q):
+            return (
+                m.soc[q + 1]
+                == m.soc[q]
+                + power_cap / 4
+                * (
+                    eta_cha * m.cha_ida[q]
+                    - (1 / eta_dis) * m.dis_ida[q]
+                    + m.cha_ida_close[q]
+                    - m.dis_ida_close[q]
+                    + step1_cha_daa[q - 1]
+                    - step1_dis_daa[q - 1]
+                )
+            )
+
+        model.soc_dynamics = pyo.Constraint(model.Q, rule=soc_step)
+
+        volume_limit = energy_cap * n_hours / 24 * self.n_cycles
+        model.charge_cycle_limit = pyo.Constraint(
+            rule=lambda m: sum(m.cha_ida[q] for q in m.Q) * power_cap / 4 + sum(step1_cha_daa) * power_cap / 4
+            <= volume_limit
+        )
+        model.discharge_cycle_limit = pyo.Constraint(
+            rule=lambda m: sum(m.dis_ida[q] for q in m.Q) * power_cap / 4 + sum(step1_dis_daa) * power_cap / 4
+            <= volume_limit
+        )
+
+        model.cha_close_logic = pyo.Constraint(
+            model.Q, rule=lambda m, q: m.cha_ida_close[q] <= step1_dis_daa[q - 1] * m.can_close_buy[q]
+        )
+        model.dis_close_logic = pyo.Constraint(
+            model.Q, rule=lambda m, q: m.dis_ida_close[q] <= step1_cha_daa[q - 1] * m.can_close_sell[q]
+        )
+
+        model.charge_rate_limit = pyo.Constraint(model.Q, rule=lambda m, q: m.cha_ida[q] + step1_cha_daa[q - 1] <= 1)
+        model.discharge_rate_limit = pyo.Constraint(
+            model.Q, rule=lambda m, q: m.dis_ida[q] + step1_dis_daa[q - 1] <= 1
+        )
+
+        # Objective: combine DAA and IDA trades
+        model.obj = pyo.Objective(
+            expr=sum(
+                self.price_list_daa_q[q - 1] * power_cap / 4 * (step1_dis_daa[q - 1] - step1_cha_daa[q - 1])
+                + self.price_list_ida[q - 1]
+                * power_cap
+                / 4
+                * (
+                    model.dis_ida[q]
+                    + model.dis_ida_close[q]
+                    - model.cha_ida[q]
+                    - model.cha_ida_close[q]
+                )
+                for q in model.Q
+            ),
+            sense=pyo.maximize,
+        )
+
+        solver = self.set_highs_solver()
+        solver.solve(model)
+
+        soc_ida = [model.soc[q].value for q in range(1, N + 1)]
+        cha_ida = [model.cha_ida[q].value for q in model.Q]
+        dis_ida = [model.dis_ida[q].value for q in model.Q]
+        cha_ida_close = [model.cha_ida_close[q].value for q in model.Q]
+        dis_ida_close = [model.dis_ida_close[q].value for q in model.Q]
+
+        profit_ida = sum(
+            self.price_list_daa_q[q - 1]
+            * (
+                eta_dis * (power_cap / 4) * step1_dis_daa[q - 1]
+                - (power_cap / 4) / eta_cha * step1_cha_daa[q - 1]
+            )
+            + self.price_list_ida[q - 1]
+            * (
+                eta_dis * (power_cap / 4) * (dis_ida[q - 1] + dis_ida_close[q - 1])
+                - (power_cap / 4) / eta_cha * (cha_ida[q - 1] + cha_ida_close[q - 1])
+            )
+            for q in range(1, N + 1)
+        )
+
+        cha_combined = np.asarray(step1_cha_daa) - np.asarray(dis_ida_close) + np.asarray(cha_ida)
+        dis_combined = np.asarray(step1_dis_daa) - np.asarray(cha_ida_close) + np.asarray(dis_ida)
+
+        return (
+            soc_ida,
+            cha_ida,
+            dis_ida,
+            cha_ida_close,
+            dis_ida_close,
+            profit_ida,
+            cha_combined.tolist(),
+            dis_combined.tolist(),
+        )

--- a/main.py
+++ b/main.py
@@ -1,0 +1,157 @@
+"""Example script running the battery optimisation workflow."""
+
+from pathlib import Path
+
+import numpy as np
+
+from V9_optimizer import optimizer
+from visualizer import (
+    analyze_step1_results,
+    calculate_real_cycles,
+    combine_charge_discharge,
+    export_all_time_series_with_charts,
+    export_full_results_to_excel_premium,
+    auswertung_transaktionen_stuendlich,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+N_DAYS = 1
+N_CYCLES = 4
+C_RATE = 1.0
+ENERGY_CAP = 10000  # kWh
+MIN_SOC = 0
+MAX_SOC = 10000
+ETA_CHA = 1.0
+ETA_DIS = 1.0
+
+EXCEL_PATH_DAA = Path("path_to_day_ahead_prices.xlsx")
+EXCEL_PATH_IDA = Path("path_to_intraday_prices.xlsx")
+
+# ---------------------------------------------------------------------------
+# Run optimisation
+# ---------------------------------------------------------------------------
+opt = optimizer(
+    n_days=N_DAYS,
+    n_cycles=N_CYCLES,
+    c_rate=C_RATE,
+    energy_cap=ENERGY_CAP,
+    eta_cha=ETA_CHA,
+    eta_dis=ETA_DIS,
+    min_soc=MIN_SOC,
+    max_soc=MAX_SOC,
+    excel_path_ida=str(EXCEL_PATH_IDA),
+    excel_path_daa=str(EXCEL_PATH_DAA),
+)
+
+(
+    soc_daa_h,
+    soc_q,
+    cha_daa_quarters,
+    dis_daa_quarters,
+    profit_daa,
+    cha_daa_h,
+    dis_daa_h,
+    cha_daa_q_real,
+    dis_daa_q_real,
+) = opt.step1_optimize_daa()
+
+(
+    step2_soc_ida,
+    cha_ida,
+    dis_ida,
+    cha_ida_close,
+    dis_ida_close,
+    profit_ida,
+    combined_cha,
+    combined_dis,
+) = opt.step2_optimize_ida(
+    N_DAYS * 24,
+    ENERGY_CAP,
+    ENERGY_CAP * C_RATE,
+    ETA_CHA,
+    ETA_DIS,
+    cha_daa_quarters,
+    dis_daa_quarters,
+)
+
+print(f"Profit DAA: {profit_daa:.2f} €")
+print(f"Profit IDA: {profit_ida:.2f} €")
+
+# ---------------------------------------------------------------------------
+# Visualisation & export
+# ---------------------------------------------------------------------------
+analyze_step1_results(
+    soc_daa_hours=soc_daa_h,
+    cha_daa_quarters=cha_daa_quarters,
+    dis_daa_quarters=dis_daa_quarters,
+    price_list_hourly=opt.price_list_daa,
+    power_cap=opt.power_cap,
+    n_hours=opt.n_hours,
+)
+
+calculate_real_cycles(
+    cha_quarters=cha_daa_quarters,
+    dis_quarters=dis_daa_quarters,
+    power_cap=opt.power_cap,
+    n_hours=opt.n_hours,
+    min_soc=MIN_SOC,
+    max_soc=MAX_SOC,
+    allowed_cycles=N_CYCLES,
+    eta_cha=ETA_CHA,
+    eta_dis=ETA_DIS,
+)
+
+energy_profile = combine_charge_discharge(
+    cha_quarters=cha_daa_quarters,
+    dis_quarters=dis_daa_quarters,
+    power_cap=opt.power_cap,
+)
+
+auswertung_transaktionen_stuendlich(
+    cha_daa_h,
+    dis_daa_h,
+    opt.price_list_daa,
+    opt.power_cap,
+)
+
+export_all_time_series_with_charts(
+    soc_q,
+    cha_daa_quarters,
+    dis_daa_quarters,
+    cha_daa_q_real,
+    dis_daa_q_real,
+    step2_soc_ida,
+    cha_ida,
+    dis_ida,
+    cha_ida_close,
+    dis_ida_close,
+    combined_cha,
+    combined_dis,
+    opt.price_list_daa,
+    opt.price_list_ida,
+    folder_path="ergebnisse",
+)
+
+export_full_results_to_excel_premium(
+    soc_hours=soc_daa_h,
+    cha_quarters=cha_daa_quarters,
+    dis_quarters=dis_daa_quarters,
+    energy_profile=energy_profile,
+    profit=profit_ida,
+    n_days=N_DAYS,
+    power_cap=opt.power_cap,
+    energy_cap=ENERGY_CAP,
+    min_soc=MIN_SOC,
+    max_soc=MAX_SOC,
+    eta_cha=ETA_CHA,
+    eta_dis=ETA_DIS,
+    n_cycles=N_CYCLES,
+    cha_daa_h=cha_daa_h,
+    dis_daa_h=dis_daa_h,
+    folder_path="ergebnisse",
+    price_list_hourly=opt.price_list_daa,
+    c_rate=C_RATE,
+    price_list_quarter=np.repeat(opt.price_list_daa, 4).tolist(),
+)

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,0 +1,364 @@
+"""Utility functions for analysing and exporting optimisation results."""
+
+from __future__ import annotations
+
+import io
+import os
+from datetime import datetime
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scipy.signal
+from openpyxl import load_workbook
+from openpyxl.drawing.image import Image
+from openpyxl.styles import Alignment, Font
+
+
+# ---------------------------------------------------------------------------
+# Plotting and analysis helpers
+# ---------------------------------------------------------------------------
+
+def analyze_step1_results(
+    soc_daa_hours: Iterable[float],
+    cha_daa_quarters: Iterable[float],
+    dis_daa_quarters: Iterable[float],
+    price_list_hourly: Iterable[float],
+    power_cap: float,
+    n_hours: int = 24,
+) -> None:
+    """Visualise step 1 results.
+
+    Creates a three-panel plot showing hourly prices with charging markers,
+    the state of charge and the charge/discharge power.
+    """
+    charge_power_hourly = [
+        np.sum(list(cha_daa_quarters)[i * 4 : (i + 1) * 4]) * power_cap / 4
+        for i in range(n_hours)
+    ]
+    discharge_power_hourly = [
+        np.sum(list(dis_daa_quarters)[i * 4 : (i + 1) * 4]) * power_cap / 4
+        for i in range(n_hours)
+    ]
+
+    price_array_hourly = np.array(list(price_list_hourly)[:n_hours])
+    soc_array_hourly = np.array(list(soc_daa_hours)[:n_hours])
+
+    local_min_idx_h = scipy.signal.argrelextrema(price_array_hourly, np.less)[0]
+    local_max_idx_h = scipy.signal.argrelextrema(price_array_hourly, np.greater)[0]
+
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 14), sharex=True)
+
+    ax1.plot(range(n_hours), price_array_hourly, label="Preis 1h (Step1)", color="black")
+    ax1.plot(local_min_idx_h, price_array_hourly[local_min_idx_h], "go", label="Minima")
+    ax1.plot(local_max_idx_h, price_array_hourly[local_max_idx_h], "ro", label="Maxima")
+    for i in range(n_hours):
+        if charge_power_hourly[i] > 0:
+            ax1.scatter(i, price_array_hourly[i], marker="^", s=100, color="green", zorder=5)
+        if discharge_power_hourly[i] > 0:
+            ax1.scatter(i, price_array_hourly[i], marker="v", s=100, color="red", zorder=5)
+    ax1.set_ylabel("Preis (€/kWh)")
+    ax1.set_title("Step1: Börsenpreise")
+    ax1.legend()
+    ax1.grid(True)
+
+    ax2.bar(range(n_hours), soc_array_hourly, label="State of Charge", color="tab:blue")
+    ax2.set_ylabel("State of Charge (kWh)")
+    ax2.set_title("Step1: Batterieladestand")
+    ax2.grid(True)
+
+    ax3.bar(range(n_hours), charge_power_hourly, width=0.5, label="Ladeleistung", color="green")
+    ax3.bar(range(n_hours), [-x for x in discharge_power_hourly], width=0.5, label="Entladeleistung", color="red")
+    ax3.axhline(0, color="black", linewidth=0.8)
+    ax3.set_xlabel("Stunden")
+    ax3.set_ylabel("Leistung (kW)")
+    ax3.grid(True)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def calculate_real_cycles(
+    cha_quarters: Iterable[float],
+    dis_quarters: Iterable[float],
+    power_cap: float,
+    n_hours: int,
+    min_soc: float,
+    max_soc: float,
+    allowed_cycles: float,
+    eta_cha: float,
+    eta_dis: float,
+) -> float:
+    """Return the actually driven cycles."""
+    energy_charged = np.sum(list(cha_quarters)) * eta_cha * power_cap / 4
+    energy_discharged = np.sum(list(dis_quarters)) / eta_dis * power_cap / 4
+    total_energy_moved = energy_charged + energy_discharged
+    usable_capacity = max_soc - min_soc
+    real_cycles = total_energy_moved / (2 * usable_capacity)
+    print(f"Cycles: allowed: {allowed_cycles * n_hours / 24:.2f}, real: {real_cycles:.2f}")
+    return real_cycles
+
+
+def combine_charge_discharge(
+    cha_quarters: Iterable[float],
+    dis_quarters: Iterable[float],
+    power_cap: float,
+) -> list[float]:
+    """Combine charge and discharge lists into one energy profile (kWh)."""
+    energy_profile = []
+    for cha, dis in zip(cha_quarters, dis_quarters):
+        energy_profile.append((cha - dis) * (power_cap / 4))
+    total_charged = sum(e for e in energy_profile if e > 0)
+    total_discharged = sum(-e for e in energy_profile if e < 0)
+    print(f"🔋 Gesamte geladen: {total_charged:.2f} kWh")
+    print(f"🔻 Gesamte entladen: {total_discharged:.2f} kWh")
+    return energy_profile
+
+
+def auswertung_transaktionen_stuendlich(
+    cha_daa_h: Iterable[float],
+    dis_daa_h: Iterable[float],
+    price_list_hourly: Iterable[float],
+    power_cap: float,
+) -> pd.DataFrame:
+    """Return a DataFrame summarising hourly transactions."""
+    daten = []
+    for stunde, (cha_pu, dis_pu, preis) in enumerate(zip(cha_daa_h, dis_daa_h, price_list_hourly), start=1):
+        geladen_kwh = cha_pu * power_cap
+        entladen_kwh = dis_pu * power_cap
+        if geladen_kwh > 0 or entladen_kwh > 0:
+            kosten = geladen_kwh * preis
+            einnahmen = entladen_kwh * preis
+            profit = einnahmen - kosten
+            daten.append({
+                "Stunde": stunde,
+                "Preis (€/kWh)": preis,
+                "Geladen (kWh)": geladen_kwh,
+                "Entladen (kWh)": entladen_kwh,
+                "Kosten (€)": kosten,
+                "Einnahmen (€)": einnahmen,
+                "Profit (€)": profit,
+            })
+    df = pd.DataFrame(daten)
+    df.loc["Summe"] = df[["Geladen (kWh)", "Entladen (kWh)", "Kosten (€)", "Einnahmen (€)", "Profit (€)"]].sum()
+    print(df)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Export functions
+# ---------------------------------------------------------------------------
+
+def export_full_results_to_excel_premium(
+    soc_hours: Iterable[float],
+    cha_quarters: Iterable[float],
+    dis_quarters: Iterable[float],
+    energy_profile: Iterable[float],
+    profit: float,
+    n_days: int,
+    power_cap: float,
+    energy_cap: float,
+    min_soc: float,
+    max_soc: float,
+    eta_cha: float,
+    eta_dis: float,
+    n_cycles: int,
+    cha_daa_h: Iterable[float],
+    dis_daa_h: Iterable[float],
+    folder_path: str,
+    price_list_hourly: Iterable[float],
+    c_rate: float,
+    price_list_quarter: Iterable[float],
+) -> None:
+    """Export results and input parameters to an Excel file."""
+    os.makedirs(folder_path, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M")
+    filename = f"results_{timestamp}_{n_days}days.xlsx"
+    full_path = os.path.join(folder_path, filename)
+
+    df_inputs = pd.DataFrame(
+        {
+            "Parameter": [
+                "power_cap (kW)",
+                "energy_cap (kWh)",
+                "min_soc (kWh)",
+                "max_soc (kWh)",
+                "eta_cha",
+                "eta_dis",
+                "n_cycles",
+                "n_days",
+                "C-Rate",
+            ],
+            "Wert": [
+                power_cap,
+                energy_cap,
+                min_soc,
+                max_soc,
+                eta_cha,
+                eta_dis,
+                n_cycles,
+                n_days,
+                c_rate,
+            ],
+        }
+    )
+
+    min_len = min(len(list(soc_hours)), len(list(price_list_hourly)), len(list(cha_daa_h)), len(list(dis_daa_h)))
+    df_soc = pd.DataFrame(
+        {
+            "Stunde": range(1, min_len + 1),
+            "State of Charge (kWh)": list(soc_hours)[:min_len],
+            "Preis Stunde": list(price_list_hourly)[:min_len],
+            "Ladeleistung (p.u.)": list(cha_daa_h)[:min_len],
+            "Entladeleistung (p.u.)": list(dis_daa_h)[:min_len],
+        }
+    )
+
+    min_len_q = min(len(list(energy_profile)), len(list(cha_quarters)), len(list(dis_quarters)), len(list(price_list_quarter)))
+    df_energy = pd.DataFrame(
+        {
+            "Viertelstunde": range(1, min_len_q + 1),
+            "Lade/Entladeenergie (kWh)": list(energy_profile)[:min_len_q],
+            "Ladeleistung (p.u.)": list(cha_quarters)[:min_len_q],
+            "Entladeleistung (p.u.)": list(dis_quarters)[:min_len_q],
+            "Preis": list(price_list_quarter)[:min_len_q],
+        }
+    )
+
+    df_profit = pd.DataFrame({"Profit (€)": [profit]})
+
+    with pd.ExcelWriter(full_path, engine="openpyxl") as writer:
+        df_inputs.to_excel(writer, sheet_name="Eingabedaten", index=False)
+        df_soc.to_excel(writer, sheet_name="State_of_Charge", index=False)
+        df_energy.to_excel(writer, sheet_name="Energy_Profile", index=False)
+        df_profit.to_excel(writer, sheet_name="Profit", index=False)
+
+    img_path_soc = os.path.join(folder_path, "soc_plot.png")
+    img_path_energy = os.path.join(folder_path, "energy_plot.png")
+
+    plt.figure(figsize=(10, 4))
+    plt.bar(range(len(list(soc_hours))), list(soc_hours), label="SoC", color="blue")
+    plt.title("State of Charge Verlauf")
+    plt.xlabel("Stunde")
+    plt.ylabel("SoC (kWh)")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(img_path_soc)
+    plt.close()
+
+    plt.figure(figsize=(10, 4))
+    plt.bar(range(len(list(energy_profile))), list(energy_profile), label="Lade/Entladeenergie", color="purple")
+    plt.axhline(0, color="black", linewidth=0.8)
+    plt.title("Lade-/Entladeprofil")
+    plt.xlabel("Viertelstunde")
+    plt.ylabel("Energie (kWh)")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(img_path_energy)
+    plt.close()
+
+    wb = load_workbook(full_path)
+    for sheet_name in wb.sheetnames:
+        ws = wb[sheet_name]
+        for cell in ws[1]:
+            cell.font = Font(bold=True)
+            cell.alignment = Alignment(horizontal="center")
+        for column_cells in ws.columns:
+            max_length = 0
+            column = column_cells[0].column_letter
+            for cell in column_cells:
+                if cell.value:
+                    max_length = max(max_length, len(str(cell.value)))
+            ws.column_dimensions[column].width = max_length + 2
+
+    ws_chart = wb.create_sheet("Diagramme")
+    img1 = Image(img_path_soc)
+    img2 = Image(img_path_energy)
+    img1.width = img2.width = 800
+    img1.height = img2.height = 400
+    ws_chart.add_image(img1, "A1")
+    ws_chart.add_image(img2, "A30")
+    wb.save(full_path)
+
+    os.remove(img_path_soc)
+    os.remove(img_path_energy)
+    print(f"✅ Premium-Excel erfolgreich gespeichert unter: {full_path}")
+
+
+def export_all_time_series_with_charts(
+    soc_q: Iterable[float],
+    cha_daa_quarters: Iterable[float],
+    dis_daa_quarters: Iterable[float],
+    cha_daa_q_real: Iterable[float],
+    dis_daa_q_real: Iterable[float],
+    step2_soc_ida: Iterable[float],
+    cha_ida: Iterable[float],
+    dis_ida: Iterable[float],
+    step2_cha_ida_close: Iterable[float],
+    step2_dis_ida_close: Iterable[float],
+    combined_cha: Iterable[float],
+    combined_dis: Iterable[float],
+    price_list_daa: Iterable[float],
+    price_list_ida: Iterable[float],
+    folder_path: str = ".",
+) -> None:
+    """Export all quarter-hourly time series to Excel and create charts."""
+    os.makedirs(folder_path, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"time_series_quarterly_{ts}.xlsx"
+    filepath = os.path.join(folder_path, filename)
+
+    N = len(list(cha_daa_quarters))
+    price_daa_q = np.repeat(list(price_list_daa), 4)[:N]
+    price_ida_q = list(price_list_ida)[:N]
+
+    df = pd.DataFrame(
+        {
+            "Viertelstunde": range(1, N + 1),
+            "Price_DAA_€/kWh": price_daa_q,
+            "Price_IDA_€/kWh": price_ida_q,
+            "SoC_DAA_kWh": list(soc_q),
+            "DAA_Charge_pu": list(cha_daa_quarters),
+            "DAA_Discharge_pu": list(dis_daa_quarters),
+            "DAA_Charge_Real_kWh": list(cha_daa_q_real),
+            "DAA_Discharge_Real_kWh": list(dis_daa_q_real),
+            "SoC_IDA_kWh": list(step2_soc_ida),
+            "IDA_Charge_pu": list(cha_ida),
+            "IDA_Discharge_pu": list(dis_ida),
+            "IDA_Close_Charge_pu": list(step2_cha_ida_close),
+            "IDA_Close_Discharge_pu": list(step2_dis_ida_close),
+            "Combined_Charge_pu": list(combined_cha),
+            "Combined_Discharge_pu": list(combined_dis),
+        }
+    )
+
+    with pd.ExcelWriter(filepath, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name="QuarterlyData", index=False)
+
+    charts: list[tuple[str, io.BytesIO]] = []
+    for col in df.columns:
+        if col == "Viertelstunde":
+            continue
+        fig, ax = plt.subplots(figsize=(6, 3))
+        ax.plot(df["Viertelstunde"], df[col])
+        ax.set_title(col)
+        ax.set_xlabel("Viertelstunde")
+        ax.grid(True)
+        buf = io.BytesIO()
+        fig.tight_layout()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        buf.seek(0)
+        charts.append((col, buf))
+
+    wb = load_workbook(filepath)
+    ws_chart = wb.create_sheet("Charts")
+    row = 1
+    for col_name, img_buf in charts:
+        img = Image(img_buf)
+        img.anchor = f"A{row}"
+        ws_chart.add_image(img)
+        row += 20
+    wb.save(filepath)
+    print(f"✅ Alle Zeitreihen + Diagramme exportiert nach: {filepath}")


### PR DESCRIPTION
## Summary
- implement `V9_optimizer` with step1/day-ahead and step2/intraday optimisation
- add `visualizer` helpers for plotting and Excel exports
- provide `main.py` as example usage script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684153df855c832cac02bc2d5f2b750d