### PR TITLE
Add intraday plotting

### DIFF
--- a/V9_optimizer.py
+++ b/V9_optimizer.py
@@ -57,6 +57,18 @@ class optimizer:
         self.price_list_daa_q = np.repeat(self.price_list_daa, 4)
 
     @staticmethod
+    def _calc_can_charge(prices: list[float], eta_cha: float, eta_dis: float) -> list[int]:
+        """Return a binary list indicating profitable charging."""
+        best_future = [
+            max(prices[t:]) if t < len(prices) else prices[-1]
+            for t in range(len(prices))
+        ]
+        return [
+            1 if best_future[t] * eta_dis > prices[t] / eta_cha else 0
+            for t in range(len(prices))
+        ]
+
+    @staticmethod
     def _load_prices(path: str) -> list[float]:
         """Return a list of prices (€/kWh) from an Excel file."""
         xls = pd.ExcelFile(path)
@@ -94,14 +106,7 @@ class optimizer:
         max_soc = self.max_soc
 
         # Profit trigger
-        best_future_price = [
-            max(self.price_list_daa[t:]) if t < len(self.price_list_daa) else self.price_list_daa[-1]
-            for t in range(len(self.price_list_daa))
-        ]
-        can_charge = [
-            1 if best_future_price[t] * eta_dis > self.price_list_daa[t] / eta_cha else 0
-            for t in range(len(self.price_list_daa))
-        ]
+        can_charge = self._calc_can_charge(self.price_list_daa, eta_cha, eta_dis)
 
         # Sets
         model.T = pyo.RangeSet(1, n_hours)
@@ -205,14 +210,7 @@ class optimizer:
         )
 
         # Profit trigger similar as step1
-        best_future_price = [
-            max(self.price_list_ida[t:]) if t < len(self.price_list_ida) else self.price_list_ida[-1]
-            for t in range(len(self.price_list_ida))
-        ]
-        can_charge = [
-            1 if best_future_price[t] * eta_dis > self.price_list_ida[t] / eta_cha else 0
-            for t in range(len(self.price_list_ida))
-        ]
+        can_charge = self._calc_can_charge(self.price_list_ida, eta_cha, eta_dis)
         model.can_charge = pyo.Param(model.Q, initialize={q: can_charge[q - 1] for q in range(1, N + 1)}, within=pyo.Binary)
 
         # Variables

--- a/main.py
+++ b/main.py
@@ -7,11 +7,13 @@ import numpy as np
 from V9_optimizer import optimizer
 from visualizer import (
     analyze_step1_results,
+    analyze_step2_results,
     calculate_real_cycles,
     combine_charge_discharge,
     export_all_time_series_with_charts,
     export_full_results_to_excel_premium,
     auswertung_transaktionen_stuendlich,
+    auswertung_transaktionen_intraday,
 )
 
 # ---------------------------------------------------------------------------
@@ -32,126 +34,149 @@ EXCEL_PATH_IDA = Path("path_to_intraday_prices.xlsx")
 # ---------------------------------------------------------------------------
 # Run optimisation
 # ---------------------------------------------------------------------------
-opt = optimizer(
-    n_days=N_DAYS,
-    n_cycles=N_CYCLES,
-    c_rate=C_RATE,
-    energy_cap=ENERGY_CAP,
-    eta_cha=ETA_CHA,
-    eta_dis=ETA_DIS,
-    min_soc=MIN_SOC,
-    max_soc=MAX_SOC,
-    excel_path_ida=str(EXCEL_PATH_IDA),
-    excel_path_daa=str(EXCEL_PATH_DAA),
-)
 
-(
-    soc_daa_h,
-    soc_q,
-    cha_daa_quarters,
-    dis_daa_quarters,
-    profit_daa,
-    cha_daa_h,
-    dis_daa_h,
-    cha_daa_q_real,
-    dis_daa_q_real,
-) = opt.step1_optimize_daa()
 
-(
-    step2_soc_ida,
-    cha_ida,
-    dis_ida,
-    cha_ida_close,
-    dis_ida_close,
-    profit_ida,
-    combined_cha,
-    combined_dis,
-) = opt.step2_optimize_ida(
-    N_DAYS * 24,
-    ENERGY_CAP,
-    ENERGY_CAP * C_RATE,
-    ETA_CHA,
-    ETA_DIS,
-    cha_daa_quarters,
-    dis_daa_quarters,
-)
+def main() -> None:
+    opt = optimizer(
+        n_days=N_DAYS,
+        n_cycles=N_CYCLES,
+        c_rate=C_RATE,
+        energy_cap=ENERGY_CAP,
+        eta_cha=ETA_CHA,
+        eta_dis=ETA_DIS,
+        min_soc=MIN_SOC,
+        max_soc=MAX_SOC,
+        excel_path_ida=str(EXCEL_PATH_IDA),
+        excel_path_daa=str(EXCEL_PATH_DAA),
+    )
 
-print(f"Profit DAA: {profit_daa:.2f} €")
-print(f"Profit IDA: {profit_ida:.2f} €")
+    (
+        soc_daa_h,
+        soc_q,
+        cha_daa_quarters,
+        dis_daa_quarters,
+        profit_daa,
+        cha_daa_h,
+        dis_daa_h,
+        cha_daa_q_real,
+        dis_daa_q_real,
+    ) = opt.step1_optimize_daa()
 
-# ---------------------------------------------------------------------------
-# Visualisation & export
-# ---------------------------------------------------------------------------
-analyze_step1_results(
-    soc_daa_hours=soc_daa_h,
-    cha_daa_quarters=cha_daa_quarters,
-    dis_daa_quarters=dis_daa_quarters,
-    price_list_hourly=opt.price_list_daa,
-    power_cap=opt.power_cap,
-    n_hours=opt.n_hours,
-)
+    (
+        step2_soc_ida,
+        cha_ida,
+        dis_ida,
+        cha_ida_close,
+        dis_ida_close,
+        profit_ida,
+        combined_cha,
+        combined_dis,
+    ) = opt.step2_optimize_ida(
+        N_DAYS * 24,
+        ENERGY_CAP,
+        ENERGY_CAP * C_RATE,
+        ETA_CHA,
+        ETA_DIS,
+        cha_daa_quarters,
+        dis_daa_quarters,
+    )
 
-calculate_real_cycles(
-    cha_quarters=cha_daa_quarters,
-    dis_quarters=dis_daa_quarters,
-    power_cap=opt.power_cap,
-    n_hours=opt.n_hours,
-    min_soc=MIN_SOC,
-    max_soc=MAX_SOC,
-    allowed_cycles=N_CYCLES,
-    eta_cha=ETA_CHA,
-    eta_dis=ETA_DIS,
-)
+    print(f"Profit DAA: {profit_daa:.2f} €")
+    print(f"Profit IDA: {profit_ida:.2f} €")
 
-energy_profile = combine_charge_discharge(
-    cha_quarters=cha_daa_quarters,
-    dis_quarters=dis_daa_quarters,
-    power_cap=opt.power_cap,
-)
+    # -----------------------------------------------------------------------
+    # Visualisation & export
+    # -----------------------------------------------------------------------
+    analyze_step1_results(
+        soc_daa_hours=soc_daa_h,
+        cha_daa_quarters=cha_daa_quarters,
+        dis_daa_quarters=dis_daa_quarters,
+        price_list_hourly=opt.price_list_daa,
+        power_cap=opt.power_cap,
+        n_hours=opt.n_hours,
+    )
 
-auswertung_transaktionen_stuendlich(
-    cha_daa_h,
-    dis_daa_h,
-    opt.price_list_daa,
-    opt.power_cap,
-)
+    calculate_real_cycles(
+        cha_quarters=cha_daa_quarters,
+        dis_quarters=dis_daa_quarters,
+        power_cap=opt.power_cap,
+        n_hours=opt.n_hours,
+        min_soc=MIN_SOC,
+        max_soc=MAX_SOC,
+        allowed_cycles=N_CYCLES,
+        eta_cha=ETA_CHA,
+        eta_dis=ETA_DIS,
+    )
 
-export_all_time_series_with_charts(
-    soc_q,
-    cha_daa_quarters,
-    dis_daa_quarters,
-    cha_daa_q_real,
-    dis_daa_q_real,
-    step2_soc_ida,
-    cha_ida,
-    dis_ida,
-    cha_ida_close,
-    dis_ida_close,
-    combined_cha,
-    combined_dis,
-    opt.price_list_daa,
-    opt.price_list_ida,
-    folder_path="ergebnisse",
-)
+    energy_profile = combine_charge_discharge(
+        cha_quarters=cha_daa_quarters,
+        dis_quarters=dis_daa_quarters,
+        power_cap=opt.power_cap,
+    )
 
-export_full_results_to_excel_premium(
-    soc_hours=soc_daa_h,
-    cha_quarters=cha_daa_quarters,
-    dis_quarters=dis_daa_quarters,
-    energy_profile=energy_profile,
-    profit=profit_ida,
-    n_days=N_DAYS,
-    power_cap=opt.power_cap,
-    energy_cap=ENERGY_CAP,
-    min_soc=MIN_SOC,
-    max_soc=MAX_SOC,
-    eta_cha=ETA_CHA,
-    eta_dis=ETA_DIS,
-    n_cycles=N_CYCLES,
-    cha_daa_h=cha_daa_h,
-    dis_daa_h=dis_daa_h,
-    folder_path="ergebnisse",
-    price_list_hourly=opt.price_list_daa,
-    c_rate=C_RATE,
-    price_list_quarter=np.repeat(opt.price_list_daa, 4).tolist(),
-)
+    auswertung_transaktionen_stuendlich(
+        cha_daa_h,
+        dis_daa_h,
+        opt.price_list_daa,
+        opt.power_cap,
+    )
+
+    analyze_step2_results(
+        soc_ida_quarters=step2_soc_ida,
+        cha_quarters=combined_cha,
+        dis_quarters=combined_dis,
+        price_list_quarter=opt.price_list_ida,
+        power_cap=opt.power_cap,
+        n_hours=opt.n_hours,
+    )
+
+    auswertung_transaktionen_intraday(
+        combined_cha,
+        combined_dis,
+        opt.price_list_ida,
+        opt.power_cap,
+    )
+
+    export_all_time_series_with_charts(
+        soc_q,
+        cha_daa_quarters,
+        dis_daa_quarters,
+        cha_daa_q_real,
+        dis_daa_q_real,
+        step2_soc_ida,
+        cha_ida,
+        dis_ida,
+        cha_ida_close,
+        dis_ida_close,
+        combined_cha,
+        combined_dis,
+        opt.price_list_daa,
+        opt.price_list_ida,
+        folder_path="ergebnisse",
+    )
+
+    export_full_results_to_excel_premium(
+        soc_hours=soc_daa_h,
+        cha_quarters=cha_daa_quarters,
+        dis_quarters=dis_daa_quarters,
+        energy_profile=energy_profile,
+        profit=profit_ida,
+        n_days=N_DAYS,
+        power_cap=opt.power_cap,
+        energy_cap=ENERGY_CAP,
+        min_soc=MIN_SOC,
+        max_soc=MAX_SOC,
+        eta_cha=ETA_CHA,
+        eta_dis=ETA_DIS,
+        n_cycles=N_CYCLES,
+        cha_daa_h=cha_daa_h,
+        dis_daa_h=dis_daa_h,
+        folder_path="ergebnisse",
+        price_list_hourly=opt.price_list_daa,
+        c_rate=C_RATE,
+        price_list_quarter=np.repeat(opt.price_list_daa, 4).tolist(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/visualizer.py
+++ b/visualizer.py
@@ -79,6 +79,56 @@ def analyze_step1_results(
     plt.show()
 
 
+def analyze_step2_results(
+    soc_ida_quarters: Iterable[float],
+    cha_quarters: Iterable[float],
+    dis_quarters: Iterable[float],
+    price_list_quarter: Iterable[float],
+    power_cap: float,
+    n_hours: int = 24,
+) -> None:
+    """Visualise step 2 intraday results."""
+    n_quarters = 4 * n_hours
+    charge_power = [cha * power_cap for cha in list(cha_quarters)[:n_quarters]]
+    discharge_power = [dis * power_cap for dis in list(dis_quarters)[:n_quarters]]
+
+    price_array = np.array(list(price_list_quarter)[:n_quarters])
+    soc_array = np.array(list(soc_ida_quarters)[:n_quarters])
+
+    local_min_idx = scipy.signal.argrelextrema(price_array, np.less)[0]
+    local_max_idx = scipy.signal.argrelextrema(price_array, np.greater)[0]
+
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 14), sharex=True)
+
+    ax1.plot(range(n_quarters), price_array, label="Preis 15min (Step2)", color="black")
+    ax1.plot(local_min_idx, price_array[local_min_idx], "go", label="Minima")
+    ax1.plot(local_max_idx, price_array[local_max_idx], "ro", label="Maxima")
+    for i in range(n_quarters):
+        if charge_power[i] > 0:
+            ax1.scatter(i, price_array[i], marker="^", s=60, color="green", zorder=5)
+        if discharge_power[i] > 0:
+            ax1.scatter(i, price_array[i], marker="v", s=60, color="red", zorder=5)
+    ax1.set_ylabel("Preis (€/kWh)")
+    ax1.set_title("Step2: Intradaypreise")
+    ax1.legend()
+    ax1.grid(True)
+
+    ax2.bar(range(n_quarters), soc_array, label="State of Charge", color="tab:blue")
+    ax2.set_ylabel("State of Charge (kWh)")
+    ax2.set_title("Step2: Batterieladestand")
+    ax2.grid(True)
+
+    ax3.bar(range(n_quarters), charge_power, width=0.5, label="Ladeleistung", color="green")
+    ax3.bar(range(n_quarters), [-x for x in discharge_power], width=0.5, label="Entladeleistung", color="red")
+    ax3.axhline(0, color="black", linewidth=0.8)
+    ax3.set_xlabel("Viertelstunden")
+    ax3.set_ylabel("Leistung (kW)")
+    ax3.grid(True)
+
+    plt.tight_layout()
+    plt.show()
+
+
 def calculate_real_cycles(
     cha_quarters: Iterable[float],
     dis_quarters: Iterable[float],
@@ -106,9 +156,9 @@ def combine_charge_discharge(
     power_cap: float,
 ) -> list[float]:
     """Combine charge and discharge lists into one energy profile (kWh)."""
-    energy_profile = []
-    for cha, dis in zip(cha_quarters, dis_quarters):
-        energy_profile.append((cha - dis) * (power_cap / 4))
+    energy_profile = [
+        (cha - dis) * (power_cap / 4) for cha, dis in zip(cha_quarters, dis_quarters)
+    ]
     total_charged = sum(e for e in energy_profile if e > 0)
     total_discharged = sum(-e for e in energy_profile if e < 0)
     print(f"🔋 Gesamte geladen: {total_charged:.2f} kWh")
@@ -123,23 +173,49 @@ def auswertung_transaktionen_stuendlich(
     power_cap: float,
 ) -> pd.DataFrame:
     """Return a DataFrame summarising hourly transactions."""
-    daten = []
-    for stunde, (cha_pu, dis_pu, preis) in enumerate(zip(cha_daa_h, dis_daa_h, price_list_hourly), start=1):
-        geladen_kwh = cha_pu * power_cap
-        entladen_kwh = dis_pu * power_cap
-        if geladen_kwh > 0 or entladen_kwh > 0:
-            kosten = geladen_kwh * preis
-            einnahmen = entladen_kwh * preis
-            profit = einnahmen - kosten
-            daten.append({
-                "Stunde": stunde,
-                "Preis (€/kWh)": preis,
-                "Geladen (kWh)": geladen_kwh,
-                "Entladen (kWh)": entladen_kwh,
-                "Kosten (€)": kosten,
-                "Einnahmen (€)": einnahmen,
-                "Profit (€)": profit,
-            })
+    daten = [
+        {
+            "Stunde": stunde,
+            "Preis (€/kWh)": preis,
+            "Geladen (kWh)": cha_pu * power_cap,
+            "Entladen (kWh)": dis_pu * power_cap,
+            "Kosten (€)": cha_pu * power_cap * preis,
+            "Einnahmen (€)": dis_pu * power_cap * preis,
+            "Profit (€)": dis_pu * power_cap * preis - cha_pu * power_cap * preis,
+        }
+        for stunde, (cha_pu, dis_pu, preis) in enumerate(
+            zip(cha_daa_h, dis_daa_h, price_list_hourly), start=1
+        )
+        if cha_pu * power_cap > 0 or dis_pu * power_cap > 0
+    ]
+    df = pd.DataFrame(daten)
+    df.loc["Summe"] = df[["Geladen (kWh)", "Entladen (kWh)", "Kosten (€)", "Einnahmen (€)", "Profit (€)"]].sum()
+    print(df)
+    return df
+
+
+def auswertung_transaktionen_intraday(
+    cha_quarters: Iterable[float],
+    dis_quarters: Iterable[float],
+    price_list_quarter: Iterable[float],
+    power_cap: float,
+) -> pd.DataFrame:
+    """Return a DataFrame summarising quarter-hourly intraday transactions."""
+    daten = [
+        {
+            "Viertelstunde": q,
+            "Preis (€/kWh)": preis,
+            "Geladen (kWh)": cha_pu * power_cap / 4,
+            "Entladen (kWh)": dis_pu * power_cap / 4,
+            "Kosten (€)": cha_pu * power_cap / 4 * preis,
+            "Einnahmen (€)": dis_pu * power_cap / 4 * preis,
+            "Profit (€)": dis_pu * power_cap / 4 * preis - cha_pu * power_cap / 4 * preis,
+        }
+        for q, (cha_pu, dis_pu, preis) in enumerate(
+            zip(cha_quarters, dis_quarters, price_list_quarter), start=1
+        )
+        if cha_pu * power_cap / 4 > 0 or dis_pu * power_cap / 4 > 0
+    ]
     df = pd.DataFrame(daten)
     df.loc["Summe"] = df[["Geladen (kWh)", "Entladen (kWh)", "Kosten (€)", "Einnahmen (€)", "Profit (€)"]].sum()
     print(df)
@@ -265,11 +341,8 @@ def export_full_results_to_excel_premium(
             cell.font = Font(bold=True)
             cell.alignment = Alignment(horizontal="center")
         for column_cells in ws.columns:
-            max_length = 0
             column = column_cells[0].column_letter
-            for cell in column_cells:
-                if cell.value:
-                    max_length = max(max_length, len(str(cell.value)))
+            max_length = max((len(str(c.value)) for c in column_cells if c.value), default=0)
             ws.column_dimensions[column].width = max_length + 2
 
     ws_chart = wb.create_sheet("Diagramme")


### PR DESCRIPTION
## Summary
- plot intraday optimisation data similarly to day ahead results
- call the intraday plot from the example script

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684156db30c0832ca5353f76e3fb28b3